### PR TITLE
Add bottom drawer to profile pages

### DIFF
--- a/lib/screens/Profile/profile_page.dart
+++ b/lib/screens/Profile/profile_page.dart
@@ -274,6 +274,7 @@ class _ProfilePageState extends State<ProfilePage>
     return Scaffold(
       key: _scaffoldKey,
       backgroundColor: const Color(0xFFF8FAFF),
+      extendBodyBehindAppBar: true,
       drawer: ModernDrawerWidget(
         key: ValueKey('drawer_$_isLoggedIn'),
         isLoggedIn: _isLoggedIn,


### PR DESCRIPTION
Add `extendBodyBehindAppBar: true` to `ProfilePage` to align the drawer's position with other pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-612049bb-9fef-4855-b77b-5510b5f480ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-612049bb-9fef-4855-b77b-5510b5f480ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

