### PR TITLE
Update ui for local data editing

### DIFF
--- a/lib/screens/Profile/edit_profile_page.dart
+++ b/lib/screens/Profile/edit_profile_page.dart
@@ -3,33 +3,71 @@ import 'package:BIBOL/services/auth/students_auth_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class EditProfilePage extends StatefulWidget {
   @override
   State<EditProfilePage> createState() => _EditProfilePageState();
 }
 
-class _EditProfilePageState extends State<EditProfilePage> {
+class _EditProfilePageState extends State<EditProfilePage> with SingleTickerProviderStateMixin {
   final _formKey = GlobalKey<FormState>();
   final _emailController = TextEditingController();
+  final _phoneController = TextEditingController();
+  final _classController = TextEditingController();
 
   Map<String, dynamic>? userInfo;
   bool _isLoading = true;
   bool _isSaving = false;
+  
+  late AnimationController _animationController;
+  late Animation<double> _fadeAnimation;
+  late Animation<Offset> _slideAnimation;
 
   @override
   void initState() {
     super.initState();
+    _setupAnimations();
     _loadUserProfile();
+  }
+
+  void _setupAnimations() {
+    _animationController = AnimationController(
+      duration: const Duration(milliseconds: 800),
+      vsync: this,
+    );
+
+    _fadeAnimation = CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeInOut,
+    );
+
+    _slideAnimation = Tween<Offset>(
+      begin: const Offset(0, 0.1),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeOutCubic,
+    ));
+
+    _animationController.forward();
   }
 
   void _loadUserProfile() async {
     final user = await TokenService.getUserInfo();
+    final prefs = await SharedPreferences.getInstance();
+    
+    // Load local edits if they exist
+    final localPhone = prefs.getString('local_phone_${user?['id']}');
+    final localClass = prefs.getString('local_class_${user?['id']}');
 
     if (mounted) {
       setState(() {
         userInfo = user;
         _emailController.text = user?['email']?.toString() ?? '';
+        // Use local data if available, otherwise use original data
+        _phoneController.text = localPhone ?? user?['phone']?.toString() ?? '';
+        _classController.text = localClass ?? user?['class']?.toString() ?? '';
         _isLoading = false;
       });
     }
@@ -37,7 +75,10 @@ class _EditProfilePageState extends State<EditProfilePage> {
 
   @override
   void dispose() {
+    _animationController.dispose();
     _emailController.dispose();
+    _phoneController.dispose();
+    _classController.dispose();
     super.dispose();
   }
 
@@ -50,6 +91,13 @@ class _EditProfilePageState extends State<EditProfilePage> {
 
     try {
       final newEmail = _emailController.text.trim();
+      final newPhone = _phoneController.text.trim();
+      final newClass = _classController.text.trim();
+      
+      // Save phone and class locally
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('local_phone_${userInfo?['id']}', newPhone);
+      await prefs.setString('local_class_${userInfo?['id']}', newClass);
 
       // Call API to update email in backend
       // Backend will get student ID from JWT token
@@ -69,7 +117,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
                   SizedBox(width: 12),
                   Expanded(
                     child: Text(
-                      result['message'] ?? 'ອັບເດດອີເມວສຳເລັດແລ້ວ',
+                      'ບັນທຶກຂໍ້ມູນສຳເລັດແລ້ວ! 🎉\nອີເມວ, ເບີໂທ ແລະ ຫ້ອງຮຽນໄດ້ຮັບການອັບເດດແລ້ວ',
                       style: GoogleFonts.notoSansLao(),
                     ),
                   ),
@@ -78,9 +126,10 @@ class _EditProfilePageState extends State<EditProfilePage> {
               backgroundColor: Colors.green.shade600,
               behavior: SnackBarBehavior.floating,
               shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(16),
               ),
               margin: EdgeInsets.all(16),
+              duration: Duration(seconds: 3),
             ),
           );
 
@@ -105,7 +154,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
               backgroundColor: Colors.red.shade600,
               behavior: SnackBarBehavior.floating,
               shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(16),
               ),
               margin: EdgeInsets.all(16),
             ),
@@ -133,7 +182,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
             backgroundColor: Colors.red.shade600,
             behavior: SnackBarBehavior.floating,
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12),
+              borderRadius: BorderRadius.circular(16),
             ),
             margin: EdgeInsets.all(16),
           ),
@@ -146,41 +195,54 @@ class _EditProfilePageState extends State<EditProfilePage> {
   Widget build(BuildContext context) {
     SystemChrome.setSystemUIOverlayStyle(
       const SystemUiOverlayStyle(
-        statusBarColor: Color(0xFF07325D),
+        statusBarColor: Colors.transparent,
         statusBarIconBrightness: Brightness.light,
       ),
     );
 
     return Scaffold(
-      backgroundColor: const Color(0xFFF8FAFF),
+      backgroundColor: const Color(0xFFF5F7FA),
+      extendBodyBehindAppBar: true,
       body: _isLoading ? _buildLoadingScreen() : _buildBody(),
     );
   }
 
   Widget _buildLoadingScreen() {
     return Container(
-      decoration: const BoxDecoration(
+      decoration: BoxDecoration(
         gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [Color(0xFF07325D), Color(0xFF0A4A85)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            Color(0xFF667eea),
+            Color(0xFF764ba2),
+            Color(0xFFf093fb),
+          ],
         ),
       ),
       child: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            CircularProgressIndicator(
-              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-              strokeWidth: 3,
+            Container(
+              padding: EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Colors.white.withOpacity(0.2),
+                shape: BoxShape.circle,
+              ),
+              child: CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                strokeWidth: 3,
+              ),
             ),
             SizedBox(height: 24),
             Text(
               'ກຳລັງໂຫຼດ...',
               style: GoogleFonts.notoSansLao(
                 color: Colors.white,
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.5,
               ),
             ),
           ],
@@ -190,172 +252,284 @@ class _EditProfilePageState extends State<EditProfilePage> {
   }
 
   Widget _buildBody() {
-    return Column(
-      children: [
-        _buildHeader(),
-        Expanded(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.all(20),
-            child: Form(
-              key: _formKey,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  SizedBox(height: 8),
-                  Text(
-                    'ຂໍ້ມູນສ່ວນຕົວ',
-                    style: GoogleFonts.notoSansLao(
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
-                      color: const Color(0xFF07325D),
-                    ),
-                  ),
-                  SizedBox(height: 8),
-                  Text(
-                    'ທ່ານສາມາດແກ້ໄຂອີເມວເທົ່ານັ້ນ',
-                    style: GoogleFonts.notoSansLao(
-                      fontSize: 14,
-                      color: Colors.grey.shade600,
-                    ),
-                  ),
-                  SizedBox(height: 24),
-
-                  // Read-only: Admission No
-                  _buildReadOnlyField(
-                    label: 'ລະຫັດນັກຮຽນ',
-                    value: userInfo?['admission_no']?.toString() ?? 'N/A',
-                    icon: Icons.badge_rounded,
-                  ),
-                  SizedBox(height: 16),
-
-                  // Read-only: First Name
-                  _buildReadOnlyField(
-                    label: 'ຊື່',
-                    value: userInfo?['first_name']?.toString() ?? 'N/A',
-                    icon: Icons.person_outline,
-                  ),
-                  SizedBox(height: 16),
-
-                  // Read-only: Last Name
-                  _buildReadOnlyField(
-                    label: 'ນາມສະກຸນ',
-                    value: userInfo?['last_name']?.toString() ?? 'N/A',
-                    icon: Icons.person_outline,
-                  ),
-                  SizedBox(height: 16),
-
-                  // Editable: Email
-                  _buildEditableEmailField(),
-                  SizedBox(height: 16),
-
-                  // Read-only: Phone
-                  if (userInfo?['phone'] != null) ...[
-                    _buildReadOnlyField(
-                      label: 'ເບີໂທລະສັບ',
-                      value: userInfo!['phone'].toString(),
-                      icon: Icons.phone_outlined,
-                    ),
-                    SizedBox(height: 16),
-                  ],
-
-                  // Read-only: Gender
-                  if (userInfo?['gender'] != null) ...[
-                    _buildReadOnlyField(
-                      label: 'ເພດ',
-                      value: _getGenderText(userInfo!['gender'].toString()),
-                      icon: Icons.wc_outlined,
-                    ),
-                    SizedBox(height: 16),
-                  ],
-
-                  // Read-only: Class
-                  if (userInfo?['class'] != null) ...[
-                    _buildReadOnlyField(
-                      label: 'ຫ້ອງຮຽນ',
-                      value: userInfo!['class'].toString(),
-                      icon: Icons.class_outlined,
-                    ),
-                    SizedBox(height: 16),
-                  ],
-
-                  // Read-only: Roll No
-                  if (userInfo?['roll_no'] != null) ...[
-                    _buildReadOnlyField(
-                      label: 'Roll No',
-                      value: userInfo!['roll_no'].toString(),
-                      icon: Icons.numbers_rounded,
-                    ),
-                    SizedBox(height: 16),
-                  ],
-
-                  SizedBox(height: 24),
-
-                  // Save button
-                  SizedBox(
-                    width: double.infinity,
-                    height: 54,
-                    child: ElevatedButton(
-                      onPressed: _isSaving ? null : _saveProfile,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: const Color(0xFF07325D),
-                        foregroundColor: Colors.white,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(16),
+    return FadeTransition(
+      opacity: _fadeAnimation,
+      child: Column(
+        children: [
+          _buildHeader(),
+          Expanded(
+            child: SingleChildScrollView(
+              physics: BouncingScrollPhysics(),
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+              child: SlideTransition(
+                position: _slideAnimation,
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Section Header
+                      Container(
+                        padding: EdgeInsets.all(20),
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: [
+                              Color(0xFF667eea).withOpacity(0.1),
+                              Color(0xFF764ba2).withOpacity(0.1),
+                            ],
+                          ),
+                          borderRadius: BorderRadius.circular(20),
+                          border: Border.all(
+                            color: Color(0xFF667eea).withOpacity(0.3),
+                            width: 1.5,
+                          ),
                         ),
-                        elevation: 2,
-                        disabledBackgroundColor: Colors.grey.shade400,
-                      ),
-                      child:
-                          _isSaving
-                              ? SizedBox(
-                                width: 24,
-                                height: 24,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2.5,
-                                  valueColor: AlwaysStoppedAnimation<Color>(
-                                    Colors.white,
-                                  ),
+                        child: Row(
+                          children: [
+                            Container(
+                              padding: EdgeInsets.all(12),
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  colors: [Color(0xFF667eea), Color(0xFF764ba2)],
                                 ),
-                              )
-                              : Row(
-                                mainAxisAlignment: MainAxisAlignment.center,
+                                borderRadius: BorderRadius.circular(12),
+                                boxShadow: [
+                                  BoxShadow(
+                                    color: Color(0xFF667eea).withOpacity(0.3),
+                                    blurRadius: 8,
+                                    offset: Offset(0, 4),
+                                  ),
+                                ],
+                              ),
+                              child: Icon(Icons.info_outline, color: Colors.white, size: 24),
+                            ),
+                            SizedBox(width: 16),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  Icon(Icons.save_rounded, size: 22),
-                                  SizedBox(width: 8),
                                   Text(
-                                    'ບັນທຶກການປ່ຽນແປງ',
+                                    'ຂໍ້ມູນສ່ວນຕົວ',
                                     style: GoogleFonts.notoSansLao(
-                                      fontSize: 17,
+                                      fontSize: 20,
                                       fontWeight: FontWeight.bold,
+                                      color: Color(0xFF667eea),
+                                    ),
+                                  ),
+                                  SizedBox(height: 4),
+                                  Text(
+                                    'ແກ້ໄຂ ອີເມວ, ເບີໂທ ແລະ ຫ້ອງຮຽນ',
+                                    style: GoogleFonts.notoSansLao(
+                                      fontSize: 13,
+                                      color: Colors.grey.shade600,
                                     ),
                                   ),
                                 ],
                               ),
-                    ),
-                  ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      SizedBox(height: 24),
 
-                  SizedBox(height: 20),
-                ],
+                      // Read-only fields
+                      _buildReadOnlyField(
+                        label: 'ລະຫັດນັກຮຽນ',
+                        value: userInfo?['admission_no']?.toString() ?? 'N/A',
+                        icon: Icons.badge_rounded,
+                        color: Colors.blue,
+                      ),
+                      SizedBox(height: 16),
+
+                      _buildReadOnlyField(
+                        label: 'ຊື່',
+                        value: userInfo?['first_name']?.toString() ?? 'N/A',
+                        icon: Icons.person_outline,
+                        color: Colors.purple,
+                      ),
+                      SizedBox(height: 16),
+
+                      _buildReadOnlyField(
+                        label: 'ນາມສະກຸນ',
+                        value: userInfo?['last_name']?.toString() ?? 'N/A',
+                        icon: Icons.person_outline,
+                        color: Colors.purple,
+                      ),
+                      SizedBox(height: 16),
+
+                      if (userInfo?['gender'] != null) ...[
+                        _buildReadOnlyField(
+                          label: 'ເພດ',
+                          value: _getGenderText(userInfo!['gender'].toString()),
+                          icon: Icons.wc_outlined,
+                          color: Colors.teal,
+                        ),
+                        SizedBox(height: 16),
+                      ],
+
+                      if (userInfo?['roll_no'] != null) ...[
+                        _buildReadOnlyField(
+                          label: 'Roll No',
+                          value: userInfo!['roll_no'].toString(),
+                          icon: Icons.numbers_rounded,
+                          color: Colors.orange,
+                        ),
+                        SizedBox(height: 16),
+                      ],
+
+                      SizedBox(height: 8),
+                      
+                      // Editable section divider
+                      Row(
+                        children: [
+                          Expanded(child: Divider(thickness: 1.5, color: Colors.grey.shade300)),
+                          Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 16),
+                            child: Text(
+                              '✏️ ແກ້ໄຂໄດ້',
+                              style: GoogleFonts.notoSansLao(
+                                fontSize: 14,
+                                fontWeight: FontWeight.bold,
+                                color: Color(0xFF667eea),
+                              ),
+                            ),
+                          ),
+                          Expanded(child: Divider(thickness: 1.5, color: Colors.grey.shade300)),
+                        ],
+                      ),
+                      SizedBox(height: 20),
+
+                      // Editable: Email
+                      _buildEditableField(
+                        label: 'ອີເມວ',
+                        controller: _emailController,
+                        icon: Icons.email_rounded,
+                        color: Colors.green,
+                        hint: 'ກະລຸນາໃສ່ອີເມວ',
+                        keyboardType: TextInputType.emailAddress,
+                        validator: (value) {
+                          if (value == null || value.trim().isEmpty) {
+                            return 'ກະລຸນາໃສ່ອີເມວ';
+                          }
+                          if (!RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$').hasMatch(value)) {
+                            return 'ກະລຸນາໃສ່ອີເມວທີ່ຖືກຕ້ອງ';
+                          }
+                          return null;
+                        },
+                      ),
+                      SizedBox(height: 16),
+
+                      // Editable: Phone
+                      _buildEditableField(
+                        label: 'ເບີໂທລະສັບ',
+                        controller: _phoneController,
+                        icon: Icons.phone_rounded,
+                        color: Colors.blue,
+                        hint: 'ກະລຸນາໃສ່ເບີໂທລະສັບ',
+                        keyboardType: TextInputType.phone,
+                        helperText: '📱 ບັນທຶກໃນເຄື່ອງເທົ່ານັ້ນ',
+                      ),
+                      SizedBox(height: 16),
+
+                      // Editable: Class
+                      _buildEditableField(
+                        label: 'ຫ້ອງຮຽນ',
+                        controller: _classController,
+                        icon: Icons.school_rounded,
+                        color: Colors.orange,
+                        hint: 'ກະລຸນາໃສ່ຫ້ອງຮຽນ',
+                        helperText: '🏫 ບັນທຶກໃນເຄື່ອງເທົ່ານັ້ນ',
+                      ),
+                      SizedBox(height: 32),
+
+                      // Save button
+                      Container(
+                        width: double.infinity,
+                        height: 58,
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: [Color(0xFF667eea), Color(0xFF764ba2)],
+                          ),
+                          borderRadius: BorderRadius.circular(20),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Color(0xFF667eea).withOpacity(0.4),
+                              blurRadius: 20,
+                              offset: Offset(0, 10),
+                            ),
+                          ],
+                        ),
+                        child: ElevatedButton(
+                          onPressed: _isSaving ? null : _saveProfile,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.transparent,
+                            shadowColor: Colors.transparent,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(20),
+                            ),
+                          ),
+                          child: _isSaving
+                              ? SizedBox(
+                                  width: 24,
+                                  height: 24,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2.5,
+                                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                                  ),
+                                )
+                              : Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Icon(Icons.save_rounded, size: 24),
+                                    SizedBox(width: 12),
+                                    Text(
+                                      'ບັນທຶກການປ່ຽນແປງ',
+                                      style: GoogleFonts.notoSansLao(
+                                        fontSize: 18,
+                                        fontWeight: FontWeight.bold,
+                                        letterSpacing: 0.5,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                        ),
+                      ),
+
+                      SizedBox(height: 24),
+                    ],
+                  ),
+                ),
               ),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 
   Widget _buildHeader() {
     return Container(
-      decoration: const BoxDecoration(
+      decoration: BoxDecoration(
         gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [Color(0xFF07325D), Color(0xFF0A4A85)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            Color(0xFF667eea),
+            Color(0xFF764ba2),
+            Color(0xFFf093fb),
+          ],
         ),
         borderRadius: BorderRadius.only(
-          bottomLeft: Radius.circular(30),
-          bottomRight: Radius.circular(30),
+          bottomLeft: Radius.circular(40),
+          bottomRight: Radius.circular(40),
         ),
+        boxShadow: [
+          BoxShadow(
+            color: Color(0xFF667eea).withOpacity(0.3),
+            blurRadius: 20,
+            offset: Offset(0, 10),
+          ),
+        ],
       ),
       child: SafeArea(
         child: Column(
@@ -363,26 +537,50 @@ class _EditProfilePageState extends State<EditProfilePage> {
           children: [
             // Top Bar
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
               child: Row(
                 children: [
-                  IconButton(
-                    onPressed: () => Navigator.pop(context),
-                    icon: Icon(
-                      Icons.arrow_back_ios_rounded,
-                      color: Colors.white,
+                  Container(
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.25),
+                      borderRadius: BorderRadius.circular(14),
+                      border: Border.all(
+                        color: Colors.white.withOpacity(0.3),
+                        width: 1.5,
+                      ),
                     ),
-                    style: IconButton.styleFrom(
-                      backgroundColor: Colors.white.withOpacity(0.2),
+                    child: IconButton(
+                      onPressed: () => Navigator.pop(context),
+                      icon: Icon(
+                        Icons.arrow_back_ios_new_rounded,
+                        color: Colors.white,
+                        size: 20,
+                      ),
+                      padding: EdgeInsets.all(10),
                     ),
                   ),
-                  SizedBox(width: 12),
-                  Text(
-                    'ແກ້ໄຂໂປຣໄຟລ໌',
-                    style: GoogleFonts.notoSansLao(
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.white,
+                  SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'ແກ້ໄຂໂປຣໄຟລ໌',
+                          style: GoogleFonts.notoSansLao(
+                            fontSize: 24,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                            letterSpacing: 0.5,
+                          ),
+                        ),
+                        Text(
+                          'ອັບເດດຂໍ້ມູນຂອງທ່ານ',
+                          style: GoogleFonts.notoSansLao(
+                            fontSize: 14,
+                            color: Colors.white.withOpacity(0.9),
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                 ],
@@ -391,26 +589,36 @@ class _EditProfilePageState extends State<EditProfilePage> {
 
             // Profile Icon
             Padding(
-              padding: const EdgeInsets.only(top: 8, bottom: 24),
+              padding: const EdgeInsets.only(top: 12, bottom: 32),
               child: Container(
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  border: Border.all(color: Colors.white, width: 3),
+                  border: Border.all(color: Colors.white, width: 4),
                   boxShadow: [
                     BoxShadow(
                       color: Colors.black.withOpacity(0.2),
-                      blurRadius: 15,
-                      offset: Offset(0, 8),
+                      blurRadius: 20,
+                      offset: Offset(0, 10),
                     ),
                   ],
                 ),
                 child: CircleAvatar(
-                  radius: 45,
+                  radius: 50,
                   backgroundColor: Colors.white,
-                  child: Icon(
-                    Icons.edit_rounded,
-                    size: 45,
-                    color: const Color(0xFF07325D),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        colors: [Color(0xFF667eea), Color(0xFF764ba2)],
+                      ),
+                      shape: BoxShape.circle,
+                    ),
+                    child: Center(
+                      child: Icon(
+                        Icons.edit_note_rounded,
+                        size: 50,
+                        color: Colors.white,
+                      ),
+                    ),
                   ),
                 ),
               ),
@@ -425,23 +633,32 @@ class _EditProfilePageState extends State<EditProfilePage> {
     required String label,
     required String value,
     required IconData icon,
+    required Color color,
   }) {
     return Container(
-      padding: EdgeInsets.all(16),
+      padding: EdgeInsets.all(18),
       decoration: BoxDecoration(
-        color: Colors.grey.shade100,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: Colors.grey.shade300),
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: color.withOpacity(0.2), width: 2),
+        boxShadow: [
+          BoxShadow(
+            color: color.withOpacity(0.08),
+            blurRadius: 10,
+            offset: Offset(0, 4),
+          ),
+        ],
       ),
       child: Row(
         children: [
           Container(
-            padding: EdgeInsets.all(10),
+            padding: EdgeInsets.all(12),
             decoration: BoxDecoration(
-              color: Colors.grey.shade300,
-              borderRadius: BorderRadius.circular(12),
+              color: color.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(color: color.withOpacity(0.3), width: 1.5),
             ),
-            child: Icon(icon, color: Colors.grey.shade600, size: 22),
+            child: Icon(icon, color: color, size: 24),
           ),
           SizedBox(width: 16),
           Expanded(
@@ -453,122 +670,158 @@ class _EditProfilePageState extends State<EditProfilePage> {
                   style: GoogleFonts.notoSansLao(
                     fontSize: 13,
                     color: Colors.grey.shade600,
-                    fontWeight: FontWeight.w500,
+                    fontWeight: FontWeight.w600,
                   ),
                 ),
-                SizedBox(height: 4),
+                SizedBox(height: 6),
                 Text(
                   value,
                   style: GoogleFonts.notoSansLao(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                    color: Colors.grey.shade700,
+                    fontSize: 17,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.grey.shade800,
                   ),
                 ),
               ],
             ),
           ),
-          Icon(Icons.lock_outline, color: Colors.grey.shade400, size: 20),
+          Container(
+            padding: EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: Colors.grey.shade100,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(Icons.lock_outline, color: Colors.grey.shade400, size: 20),
+          ),
         ],
       ),
     );
   }
 
-  Widget _buildEditableEmailField() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            Container(
-              padding: EdgeInsets.all(8),
-              decoration: BoxDecoration(
-                color: Colors.green.shade50,
-                borderRadius: BorderRadius.circular(10),
+  Widget _buildEditableField({
+    required String label,
+    required TextEditingController controller,
+    required IconData icon,
+    required Color color,
+    required String hint,
+    TextInputType? keyboardType,
+    String? helperText,
+    String? Function(String?)? validator,
+  }) {
+    return Container(
+      padding: EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: color.withOpacity(0.3), width: 2),
+        boxShadow: [
+          BoxShadow(
+            color: color.withOpacity(0.15),
+            blurRadius: 15,
+            offset: Offset(0, 6),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [color.withOpacity(0.8), color],
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                  boxShadow: [
+                    BoxShadow(
+                      color: color.withOpacity(0.3),
+                      blurRadius: 8,
+                      offset: Offset(0, 4),
+                    ),
+                  ],
+                ),
+                child: Icon(icon, color: Colors.white, size: 22),
               ),
-              child: Icon(
-                Icons.email_rounded,
-                color: Colors.green.shade600,
-                size: 20,
-              ),
-            ),
-            SizedBox(width: 10),
-            Text(
-              'ອີເມວ',
-              style: GoogleFonts.notoSansLao(
-                fontSize: 15,
-                fontWeight: FontWeight.w600,
-                color: const Color(0xFF07325D),
-              ),
-            ),
-            SizedBox(width: 8),
-            Container(
-              padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              decoration: BoxDecoration(
-                color: Colors.green.shade50,
-                borderRadius: BorderRadius.circular(6),
-              ),
-              child: Text(
-                'ແກ້ໄຂໄດ້',
-                style: GoogleFonts.notoSansLao(
-                  fontSize: 11,
-                  fontWeight: FontWeight.w600,
-                  color: Colors.green.shade700,
+              SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  label,
+                  style: GoogleFonts.notoSansLao(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: color,
+                  ),
                 ),
               ),
-            ),
-          ],
-        ),
-        SizedBox(height: 12),
-        TextFormField(
-          controller: _emailController,
-          keyboardType: TextInputType.emailAddress,
-          style: GoogleFonts.notoSansLao(
-            fontSize: 16,
-            fontWeight: FontWeight.w500,
+              Container(
+                padding: EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                decoration: BoxDecoration(
+                  color: color.withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: color.withOpacity(0.3)),
+                ),
+                child: Text(
+                  '✏️ ແກ້ໄຂໄດ້',
+                  style: GoogleFonts.notoSansLao(
+                    fontSize: 11,
+                    fontWeight: FontWeight.bold,
+                    color: color,
+                  ),
+                ),
+              ),
+            ],
           ),
-          decoration: InputDecoration(
-            hintText: 'ກະລຸນາໃສ່ອີເມວ',
-            hintStyle: GoogleFonts.notoSansLao(color: Colors.grey.shade400),
-            filled: true,
-            fillColor: Colors.white,
-            prefixIcon: Icon(
-              Icons.email_outlined,
-              color: Colors.green.shade600,
+          SizedBox(height: 14),
+          TextFormField(
+            controller: controller,
+            keyboardType: keyboardType,
+            style: GoogleFonts.notoSansLao(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: Colors.grey.shade800,
             ),
-            border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(16),
-              borderSide: BorderSide(color: Colors.grey.shade300),
+            decoration: InputDecoration(
+              hintText: hint,
+              hintStyle: GoogleFonts.notoSansLao(
+                color: Colors.grey.shade400,
+                fontWeight: FontWeight.w500,
+              ),
+              filled: true,
+              fillColor: color.withOpacity(0.05),
+              prefixIcon: Icon(icon, color: color),
+              helperText: helperText,
+              helperStyle: GoogleFonts.notoSansLao(
+                fontSize: 12,
+                color: color,
+                fontWeight: FontWeight.w600,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(16),
+                borderSide: BorderSide(color: color.withOpacity(0.3), width: 2),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(16),
+                borderSide: BorderSide(color: color.withOpacity(0.3), width: 2),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(16),
+                borderSide: BorderSide(color: color, width: 2.5),
+              ),
+              errorBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(16),
+                borderSide: BorderSide(color: Colors.red.shade400, width: 2),
+              ),
+              focusedErrorBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(16),
+                borderSide: BorderSide(color: Colors.red.shade600, width: 2.5),
+              ),
             ),
-            enabledBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(16),
-              borderSide: BorderSide(color: Colors.grey.shade300),
-            ),
-            focusedBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(16),
-              borderSide: BorderSide(color: Colors.green.shade600, width: 2),
-            ),
-            errorBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(16),
-              borderSide: BorderSide(color: Colors.red.shade400),
-            ),
-            focusedErrorBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(16),
-              borderSide: BorderSide(color: Colors.red.shade600, width: 2),
-            ),
+            validator: validator,
           ),
-          validator: (value) {
-            if (value == null || value.trim().isEmpty) {
-              return 'ກະລຸນາໃສ່ອີເມວ';
-            }
-            // Simple email validation
-            if (!RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$').hasMatch(value)) {
-              return 'ກະລຸນາໃສ່ອີເມວທີ່ຖືກຕ້ອງ';
-            }
-            return null;
-          },
-        ),
-      ],
+        ],
+      ),
     );
   }
 

--- a/lib/screens/Profile/profile_page.dart
+++ b/lib/screens/Profile/profile_page.dart
@@ -5,6 +5,7 @@ import 'package:BIBOL/widgets/shared/shared_header_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class ProfilePage extends StatefulWidget {
   @override
@@ -69,6 +70,11 @@ class _ProfilePageState extends State<ProfilePage>
         }
         _isLoading = false;
       });
+      
+      // Load local data if user is logged in
+      if (_isLoggedIn && userInfo != null) {
+        await _loadLocalData();
+      }
     }
   }
 
@@ -86,6 +92,31 @@ class _ProfilePageState extends State<ProfilePage>
           _isLoggedIn = false;
         }
         _isLoading = false;
+      });
+      
+      // Load local data if user is logged in
+      if (_isLoggedIn && userInfo != null) {
+        await _loadLocalData();
+      }
+    }
+  }
+
+  Future<void> _loadLocalData() async {
+    final prefs = await SharedPreferences.getInstance();
+    
+    // Load local edits if they exist
+    final localPhone = prefs.getString('local_phone_${userInfo?['id']}');
+    final localClass = prefs.getString('local_class_${userInfo?['id']}');
+
+    if (mounted) {
+      setState(() {
+        // Merge local data with user info
+        if (localPhone != null) {
+          userInfo!['phone'] = localPhone;
+        }
+        if (localClass != null) {
+          userInfo!['class'] = localClass;
+        }
       });
     }
   }


### PR DESCRIPTION
Revamp profile edit UI with modern design and enable local-only editing for phone and classroom fields.

The user requested a visual refresh of the profile editing page and specifically asked for the phone and classroom fields to be editable, but with the constraint that these changes should only be stored locally on the device and not persisted to the backend database. This PR implements that local storage mechanism using `SharedPreferences` and updates the UI accordingly.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ee12e45-1a0e-4192-9d19-59eb636315d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ee12e45-1a0e-4192-9d19-59eb636315d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

